### PR TITLE
Enable Java compiler parameter names flag in build conventions

### DIFF
--- a/buildSrc/src/main/groovy/java-conventions.gradle
+++ b/buildSrc/src/main/groovy/java-conventions.gradle
@@ -10,6 +10,10 @@ java {
     targetCompatibility = JavaVersion.VERSION_24
 }
 
+tasks.withType(JavaCompile) {
+    options.compilerArgs << '-parameters'
+}
+
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
## Summary
This change enables the `-parameters` compiler flag for all Java compilation tasks in the build, which preserves method parameter names in compiled bytecode.

## Key Changes
- Added `JavaCompile` task configuration to the java-conventions.gradle build script
- Enabled the `-parameters` compiler argument for all Java compilation tasks

## Implementation Details
The `-parameters` flag is a Java compiler option that instructs the compiler to store formal parameter names in the generated class files. This enables reflection-based frameworks and tools to access method parameter names at runtime without relying on external metadata or bytecode manipulation libraries. This is particularly useful for dependency injection frameworks, serialization libraries, and other tools that need to introspect method signatures.

By configuring this at the convention level, all modules in the project will automatically benefit from this setting without requiring individual configuration.

https://claude.ai/code/session_01LPrT92MaCifjZhDgFwTYtH