### PR TITLE
Add request scope to ContextHolder and improve user validation

### DIFF
--- a/infra/src/main/java/br/com/carteira/infra/carteira/component/DefaultCarteiraGateway.java
+++ b/infra/src/main/java/br/com/carteira/infra/carteira/component/DefaultCarteiraGateway.java
@@ -75,7 +75,11 @@ public class DefaultCarteiraGateway implements CarteiraGateway {
 
     private Usuario getUsuario(Carteira carteira) {
         if (Objects.isNull(holder.getUserName()) || Objects.isNull(holder.getEmail())) {
-            return usuarioService.needUsuario(carteira.getPertenceAoUsuarioRef());
+            String usuarioRef = carteira.getPertenceAoUsuarioRef();
+            if (Objects.isNull(usuarioRef)) {
+                throw new IllegalStateException("Usuario não identificado: headers 'user' e 'email' são obrigatórios");
+            }
+            return usuarioService.needUsuario(usuarioRef);
         }
 
         return usuarioService.getUsuario(holder.getUserName(), holder.getEmail());

--- a/infra/src/main/java/br/com/carteira/infra/filters/ContextHolder.java
+++ b/infra/src/main/java/br/com/carteira/infra/filters/ContextHolder.java
@@ -1,10 +1,8 @@
 package br.com.carteira.infra.filters;
 
 import org.springframework.stereotype.Component;
-import org.springframework.web.context.annotation.RequestScope;
 
 @Component
-@RequestScope
 public class ContextHolder {
     private String userName;
     private String email;

--- a/infra/src/main/java/br/com/carteira/infra/filters/ContextHolder.java
+++ b/infra/src/main/java/br/com/carteira/infra/filters/ContextHolder.java
@@ -1,8 +1,10 @@
 package br.com.carteira.infra.filters;
 
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
 
 @Component
+@RequestScope
 public class ContextHolder {
     private String userName;
     private String email;


### PR DESCRIPTION
## Summary
This PR improves user identification validation in the carteira module by adding proper request scoping to the ContextHolder component and implementing explicit null checks for user references.

## Key Changes
- **ContextHolder**: Added `@RequestScope` annotation to ensure the component is scoped to individual HTTP requests, preventing potential data leakage between concurrent requests
- **DefaultCarteiraGateway.getUsuario()**: Enhanced user validation logic:
  - Extracted `usuarioRef` to a local variable for clarity
  - Added explicit null check for `usuarioRef` with a descriptive error message
  - Throws `IllegalStateException` when user cannot be identified from either headers or carteira reference

## Implementation Details
The validation now ensures that when user identification headers ('user' and 'email') are missing, the system attempts to retrieve the user from the carteira's user reference. If that reference is also null, a clear error message is thrown indicating that the required headers are mandatory. This prevents silent failures and provides better debugging information.

https://claude.ai/code/session_01GD3Qn9TNRTQDBeFWaY75Cj